### PR TITLE
Permit an empty term

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -121,9 +121,7 @@ var Autocomplete = /** @class */ (function () {
             }, 500);
         };
         this.handleFocus = function (event) {
-            if (_this.input.value) {
-                _this.getResults(_this.input.value);
-            }
+            _this.getResults(_this.input.value);
         };
         this.handleSelect = function (result) {
             if (_this.options.onSelect && result) {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -128,6 +128,13 @@ test('on focus', () => {
   expect(autocompleteContainer.outerHTML).toMatchSnapshot()
 })
 
+test('on focus with empty term', () => {
+  input.value = ''
+  input.dispatchEvent(new Event('focus'))
+
+  expect(query.mock.calls.length).toBe(1);
+})
+
 test('on item click', () => {
   input.value = 'an'
   input.dispatchEvent(keyboardEvent('keyup', 'n'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,9 +205,7 @@ export default class Autocomplete {
   }
 
   private handleFocus = (event: FocusEvent) => {
-    if (this.input.value) {
-      this.getResults(this.input.value)
-    }
+    this.getResults(this.input.value)
   }
 
   private handleSelect = (result?: QueryResult) => {


### PR DESCRIPTION
The onQuery method should decide if we need to ignore empty query or
not. There might be a valid use case to show some suggestions
without any term.