### PR TITLE
Permit an empty term for key up event as well

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62,11 +62,6 @@ var Autocomplete = /** @class */ (function () {
                 return;
             if (_this.debounce())
                 return;
-            if (!_this.input.value) {
-                _this.resetResults();
-                _this.hide();
-                return;
-            }
             _this.getResults(_this.input.value);
         };
         this.handleKeydown = function (event) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,12 +139,6 @@ export default class Autocomplete {
     if (CONTROL_KEYS[event.key]) return
     if (this.debounce()) return
 
-    if (!this.input.value) {
-      this.resetResults()
-      this.hide()
-      return
-    }
-
     this.getResults(this.input.value)
   }
 


### PR DESCRIPTION
Similar to #2 but for key up event. It gives more control over the component behavior to the specific implementation.
